### PR TITLE
Add ability to use parameters defined in the service container

### DIFF
--- a/src/Codeception/Module/Phalcon.php
+++ b/src/Codeception/Module/Phalcon.php
@@ -454,11 +454,12 @@ class Phalcon extends Framework implements ActiveRecord, PartedModule
      * Recommended to use for unit testing.
      *
      * @param string $service    Service name
-     * @param array  $parameters Parameters [Optional]
+     * @param array|null  $parameters Parameters [Optional]. Set it to null
+     * if you want service container to use parameters defined in the config of the container
      * @return mixed
      * @part services
      */
-    public function grabServiceFromContainer($service, array $parameters = [])
+    public function grabServiceFromContainer($service, ?array $parameters = [])
     {
         if (!$this->di->has($service)) {
             $this->fail("Service $service is not available in container");

--- a/src/Codeception/Module/Phalcon.php
+++ b/src/Codeception/Module/Phalcon.php
@@ -459,7 +459,7 @@ class Phalcon extends Framework implements ActiveRecord, PartedModule
      * @return mixed
      * @part services
      */
-    public function grabServiceFromContainer($service, ?array $parameters = [])
+    public function grabServiceFromContainer($service, array $parameters = null)
     {
         if (!$this->di->has($service)) {
             $this->fail("Service $service is not available in container");


### PR DESCRIPTION
The parameter $parameters of the method get of the Phalcon's DiInterface can be array or null.

```
/**
     * Resolves the service based on its configuration
     *
     * @param string $name
     * @param array $parameters
     * @return mixed
     */
    public function get($name, $parameters = null);
```

According to this parameter Di container tries to create service. If we have an array of dependencies in our definition, such as 
```
'group' => [
         'className' => '\Acme\Group',
         'arguments' => [
             [
                 'type' => 'service',
                 'service' => 'myComponent',
             ],
         ],
     ],
```

than we can get \Acme\Group without parameters `$group = $container->get('group', null);`. In this case we get class Group with injected myComponete.
If we use `$group = $container->get('group', []);`, than we have got an error " [ArgumentCountError] Too few arguments to function Acme\Group::__construct(), 0 passed and exactly 1 expected ".


This pull request adds an ability to use parameters from the container's definition, to create a service.