### PR TITLE
Fix: `$cookie->setSecure()` always as boolean

### DIFF
--- a/src/Codeception/Lib/Connector/Phalcon.php
+++ b/src/Codeception/Lib/Connector/Phalcon.php
@@ -142,7 +142,7 @@ class Phalcon extends Client
                         $cookie->getExpiration(),
                         $cookie->getPath(),
                         $cookie->getDomain(),
-                        $cookie->getSecure(),
+                        $cookie->getSecure() ? $cookie->getSecure() : false,
                         $cookie->getHttpOnly()
                     );
                     $headers['Set-Cookie'][] = (string)$clientCookie;

--- a/src/Codeception/Lib/Connector/Phalcon.php
+++ b/src/Codeception/Lib/Connector/Phalcon.php
@@ -142,7 +142,7 @@ class Phalcon extends Client
                         $cookie->getExpiration(),
                         $cookie->getPath(),
                         $cookie->getDomain(),
-                        $cookie->getSecure() ? $cookie->getSecure() : false,
+                        (bool) $cookie->getSecure(),
                         $cookie->getHttpOnly()
                     );
                     $headers['Set-Cookie'][] = (string)$clientCookie;


### PR DESCRIPTION
$cookie->getSecure() should return a boolean, but that is not always the case (see https://github.com/phalcon/ide-stubs/blob/master/src/Phalcon/Http/Cookie.php#L98)